### PR TITLE
Fix declaration of yii\debug\LogTarget::collect()

### DIFF
--- a/src/LogTarget.php
+++ b/src/LogTarget.php
@@ -120,7 +120,7 @@ class LogTarget extends Target
      * of each message.
      * @param bool $final whether this method is called at the end of the current application
      */
-    public function collect($messages, $final)
+    public function collect($messages, bool $final): void
     {
         $this->messages = array_merge($this->messages, $messages);
         if ($final) {


### PR DESCRIPTION
Fatal error: Declaration of yii\debug\LogTarget::collect($messages, $final) must be compatible with yii\log\Target::collect($messages, bool $final): void.

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | no
| Fixed issues  | -
