### PR TITLE
Collect page output

### DIFF
--- a/src/Collector/RequestCollector.php
+++ b/src/Collector/RequestCollector.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Yiisoft\Yii\Debug\Collector;
 
+use JsonException;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Yiisoft\Yii\Http\Event\AfterRequest;
@@ -64,19 +65,21 @@ final class RequestCollector implements CollectorInterface, IndexCollectorInterf
         }
 
         if ($event instanceof BeforeRequest) {
-            $this->request = $event->getRequest();
-            $this->requestUrl = (string) $event->getRequest()->getUri();
-            $this->requestPath = $event->getRequest()->getUri()->getPath();
-            $this->requestQuery = $event->getRequest()->getUri()->getQuery();
-            $this->requestMethod = $event->getRequest()->getMethod();
-            $this->requestIsAjax = strtolower(
-                $event->getRequest()->getHeaderLine('X-Requested-With') ?? ''
-            ) === 'xmlhttprequest';
-            $this->userIp = $event->getRequest()->getServerParams()['REMOTE_ADDR'] ?? null;
+            $request = $event->getRequest();
+
+            $this->request = $request;
+            $this->requestUrl = (string) $request->getUri();
+            $this->requestPath = $request->getUri()->getPath();
+            $this->requestQuery = $request->getUri()->getQuery();
+            $this->requestMethod = $request->getMethod();
+            $this->requestIsAjax = strtolower($request->getHeaderLine('X-Requested-With')) === 'xmlhttprequest';
+            $this->userIp = $request->getServerParams()['REMOTE_ADDR'] ?? null;
         }
         if ($event instanceof AfterRequest) {
-            $this->response = $event->getResponse();
-            $this->responseStatusCode = $event->getResponse() !== null ? $event->getResponse()->getStatusCode() : 500;
+            $response = $event->getResponse();
+
+            $this->response = $response;
+            $this->responseStatusCode = $response !== null ? $response->getStatusCode() : 500;
         }
     }
 

--- a/src/Collector/RequestCollector.php
+++ b/src/Collector/RequestCollector.php
@@ -27,6 +27,22 @@ final class RequestCollector implements CollectorInterface, IndexCollectorInterf
 
     public function getCollected(): array
     {
+        $body = null;
+        if ($this->response !== null) {
+            $stream = $this->response->getBody();
+            if ($stream->isReadable() && $stream->isSeekable()) {
+                $position = $stream->tell();
+                $stream->rewind();
+                $body = $stream->getContents();
+                try {
+                    $body = json_decode($body, associative: true, flags: JSON_THROW_ON_ERROR);
+                } catch (JsonException) {
+                    // pass
+                }
+                $stream->seek($position);
+            }
+        }
+
         return [
             'requestUrl' => $this->requestUrl,
             'requestPath' => $this->requestPath,
@@ -37,6 +53,7 @@ final class RequestCollector implements CollectorInterface, IndexCollectorInterf
             'responseStatusCode' => $this->responseStatusCode,
             'request' => $this->request,
             'response' => $this->response,
+            'responseRaw' => $body,
         ];
     }
 

--- a/tests/Collector/RequestCollectorTest.php
+++ b/tests/Collector/RequestCollectorTest.php
@@ -6,6 +6,7 @@ namespace Yiisoft\Yii\Debug\Tests\Collector;
 
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\StreamInterface;
 use Psr\Http\Message\UriInterface;
 use Yiisoft\Yii\Debug\Collector\CollectorInterface;
 use Yiisoft\Yii\Debug\Collector\RequestCollector;
@@ -22,6 +23,7 @@ final class RequestCollectorTest extends CollectorTestCase
         $requestMock = $this->createMock(ServerRequestInterface::class);
         $responseMock = $this->createMock(ResponseInterface::class);
         $uriMock = $this->createMock(UriInterface::class);
+        $bodyMock = $this->createMock(StreamInterface::class);
 
         $uriMock->method('getPath')
             ->willReturn('url');
@@ -32,11 +34,16 @@ final class RequestCollectorTest extends CollectorTestCase
 
         $requestMock->method('getMethod')
             ->willReturn('GET');
+        $requestMock->method('getHeaderLine')
+            ->willReturn('');
         $requestMock->method('getUri')
             ->willReturn($uriMock);
 
         $responseMock->method('getStatusCode')
             ->willReturn(200);
+        $responseMock->method('getBody')
+            ->willReturn($bodyMock);
+
         $collector->collect(new BeforeRequest($requestMock));
         $collector->collect(new AfterRequest($responseMock));
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | #23 

Collects response and decodes it to arrays if it's a json for showing json response in the debugger as a json.