### PR TITLE
update yiisoft/profiler dependeny

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "yiisoft/assets": "^2.0.1",
         "yiisoft/di": "^1.0",
         "yiisoft/json": "^1.0",
-        "yiisoft/profiler": "^1.0.3",
+        "yiisoft/profiler": "^1.0.3|^2.0.0",
         "yiisoft/proxy": "^1.0.1",
         "yiisoft/strings": "^2.0",
         "yiisoft/validator": "3.0.x-dev",


### PR DESCRIPTION
yiisoft/profiler 2.0.0 removed php7.4 support and should still be compatible

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | 
