### PR TITLE
Change original container to proxy one

### DIFF
--- a/config/params.php
+++ b/config/params.php
@@ -2,17 +2,23 @@
 
 declare(strict_types=1);
 
+use Psr\Container\ContainerInterface;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Psr\Log\LoggerInterface;
 use Yiisoft\Assets\AssetLoaderInterface;
 use Yiisoft\Cache\CacheInterface;
+use Yiisoft\Injector\Injector;
 use Yiisoft\Router\UrlMatcherInterface;
 use Yiisoft\Validator\ValidatorInterface;
 use Yiisoft\Yii\Debug\Collector\AssetCollector;
+use Yiisoft\Yii\Debug\Collector\AssetLoaderInterfaceProxy;
 use Yiisoft\Yii\Debug\Collector\CommandCollector;
 use Yiisoft\Yii\Debug\Collector\ConsoleAppInfoCollector;
+use Yiisoft\Yii\Debug\Collector\ContainerInterfaceProxy;
 use Yiisoft\Yii\Debug\Collector\EventCollector;
+use Yiisoft\Yii\Debug\Collector\EventDispatcherInterfaceProxy;
 use Yiisoft\Yii\Debug\Collector\LogCollector;
+use Yiisoft\Yii\Debug\Collector\LoggerInterfaceProxy;
 use Yiisoft\Yii\Debug\Collector\MiddlewareCollector;
 use Yiisoft\Yii\Debug\Collector\QueueCollector;
 use Yiisoft\Yii\Debug\Collector\QueueFactoryInterfaceProxy;
@@ -20,16 +26,12 @@ use Yiisoft\Yii\Debug\Collector\QueueWorkerInterfaceProxy;
 use Yiisoft\Yii\Debug\Collector\RequestCollector;
 use Yiisoft\Yii\Debug\Collector\RouterCollector;
 use Yiisoft\Yii\Debug\Collector\ServiceCollector;
+use Yiisoft\Yii\Debug\Collector\UrlMatcherInterfaceProxy;
 use Yiisoft\Yii\Debug\Collector\ValidatorCollector;
+use Yiisoft\Yii\Debug\Collector\ValidatorInterfaceProxy;
 use Yiisoft\Yii\Debug\Collector\WebAppInfoCollector;
 use Yiisoft\Yii\Debug\Collector\WebViewCollector;
 use Yiisoft\Yii\Debug\Command\ResetCommand;
-use Yiisoft\Yii\Debug\Collector\AssetLoaderInterfaceProxy;
-use Yiisoft\Yii\Debug\Collector\ContainerInterfaceProxy;
-use Yiisoft\Yii\Debug\Collector\EventDispatcherInterfaceProxy;
-use Yiisoft\Yii\Debug\Collector\LoggerInterfaceProxy;
-use Yiisoft\Yii\Debug\Collector\UrlMatcherInterfaceProxy;
-use Yiisoft\Yii\Debug\Collector\ValidatorInterfaceProxy;
 use Yiisoft\Yii\Queue\QueueFactoryInterface;
 use Yiisoft\Yii\Queue\Worker\WorkerInterface;
 
@@ -60,6 +62,7 @@ return [
             CommandCollector::class,
         ],
         'trackedServices' => [
+            Injector::class => fn (ContainerInterface $container) => new Injector($container),
             LoggerInterface::class => [LoggerInterfaceProxy::class, LogCollector::class],
             EventDispatcherInterface::class => [EventDispatcherInterfaceProxy::class, EventCollector::class],
             QueueFactoryInterface::class => [QueueFactoryInterfaceProxy::class, QueueCollector::class],

--- a/src/Collector/ContainerInterfaceProxy.php
+++ b/src/Collector/ContainerInterfaceProxy.php
@@ -73,6 +73,10 @@ class ContainerInterfaceProxy implements ContainerInterface
 
     private function getInstance(string $id)
     {
+        if ($id === ContainerInterface::class) {
+            return $this;
+        }
+
         return $this->container->get($id);
     }
 
@@ -118,7 +122,7 @@ class ContainerInterfaceProxy implements ContainerInterface
 
     private function getServiceProxyFromCallable(callable $callback): ?object
     {
-        return $callback($this->container);
+        return $callback($this);
     }
 
     private function getCommonMethodProxy(string $service, object $instance, array $callbacks): ?object
@@ -146,7 +150,7 @@ class ContainerInterfaceProxy implements ContainerInterface
             foreach ($params as $index => $param) {
                 if (is_string($param)) {
                     try {
-                        $params[$index] = $this->container->get($param);
+                        $params[$index] = $this->get($param);
                     } catch (Exception) {
                         //leave as is
                     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️

Sometimes container that passed to some callables was original, but it should be proxy one.