### PR TITLE
Add http client proxy

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
         "jetbrains/phpstorm-attributes": "^1.0",
         "psr/container": "^2.0",
         "psr/event-dispatcher": "^1.0",
+        "psr/http-client": "^1.0",
         "psr/http-message": "^1.0",
         "psr/log": "^2.0|^3.0",
         "symfony/console": "^5.4|^6.0",

--- a/config/params.php
+++ b/config/params.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use Psr\Container\ContainerInterface;
 use Psr\EventDispatcher\EventDispatcherInterface;
+use Psr\Http\Client\ClientInterface;
 use Psr\Log\LoggerInterface;
 use Yiisoft\Assets\AssetLoaderInterface;
 use Yiisoft\Cache\CacheInterface;
@@ -17,6 +18,8 @@ use Yiisoft\Yii\Debug\Collector\ConsoleAppInfoCollector;
 use Yiisoft\Yii\Debug\Collector\ContainerInterfaceProxy;
 use Yiisoft\Yii\Debug\Collector\EventCollector;
 use Yiisoft\Yii\Debug\Collector\EventDispatcherInterfaceProxy;
+use Yiisoft\Yii\Debug\Collector\HttpClientCollector;
+use Yiisoft\Yii\Debug\Collector\HttpClientInterfaceProxy;
 use Yiisoft\Yii\Debug\Collector\LogCollector;
 use Yiisoft\Yii\Debug\Collector\LoggerInterfaceProxy;
 use Yiisoft\Yii\Debug\Collector\MiddlewareCollector;
@@ -48,6 +51,7 @@ return [
             ServiceCollector::class,
             ValidatorCollector::class,
             QueueCollector::class,
+            HttpClientCollector::class,
         ],
         'collectors.web' => [
             WebAppInfoCollector::class,
@@ -70,6 +74,7 @@ return [
             UrlMatcherInterface::class => [UrlMatcherInterfaceProxy::class, RouterCollector::class],
             ValidatorInterface::class => [ValidatorInterfaceProxy::class, ValidatorCollector::class],
             AssetLoaderInterface::class => [AssetLoaderInterfaceProxy::class, AssetCollector::class],
+            ClientInterface::class => [HttpClientInterfaceProxy::class, HttpClientCollector::class],
             CacheInterface::class,
         ],
         'dumper.excludedClasses' => [

--- a/src/Collector/HttpClientCollector.php
+++ b/src/Collector/HttpClientCollector.php
@@ -58,7 +58,7 @@ final class HttpClientCollector implements CollectorInterface, IndexCollectorInt
         if (!isset($this->requests[spl_object_id($request)])) {
             return;
         }
-        $entry = &$this->requests[spl_object_id($request)][count($this->requests[spl_object_id($request)])-1];
+        $entry = &$this->requests[spl_object_id($request)][(is_countable($this->requests[spl_object_id($request)]) ? count($this->requests[spl_object_id($request)]) : 0)-1];
         $entry['endTime'] = microtime(true);
         $entry['totalTime'] = $entry['endTime'] - $entry['startTime'];
     }

--- a/src/Collector/HttpClientCollector.php
+++ b/src/Collector/HttpClientCollector.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Yii\Debug\Collector;
+
+final class HttpClientCollector implements CollectorInterface, IndexCollectorInterface
+{
+    use CollectorTrait;
+
+    private array $requests = [];
+
+    public function getCollected(): array
+    {
+        return array_merge(...array_values($this->requests));
+    }
+
+    public function getIndexData(): array
+    {
+        return [
+            'http' => [
+                'count' => array_sum(array_map(count(...), $this->requests)),
+                'totalTime' => array_sum(
+                    array_merge(
+                        ...array_map(
+                            fn(array $entry) => array_column($entry, 'totalTime'),
+                            $this->requests
+                        )
+                    )
+                ),
+            ],
+        ];
+    }
+
+    public function collect(\Psr\Http\Message\RequestInterface $request, string $line)
+    {
+        if (!$this->isActive()) {
+            return;
+        }
+
+        $this->requests[spl_object_id($request)][] = [
+            'startTime' => microtime(true),
+            'endTime' => microtime(true),
+            'totalTime' => 0,
+            'method' => $request->getMethod(),
+            'uri' => $request->getUri()->__toString(),
+            'headers' => $request->getHeaders(),
+            'line' => $line,
+        ];
+    }
+
+    public function collectTotalTime(\Psr\Http\Message\RequestInterface $request)
+    {
+        if (!$this->isActive()) {
+            return;
+        }
+
+        if (!isset($this->requests[spl_object_id($request)])) {
+            return;
+        }
+        $entry = &$this->requests[spl_object_id($request)][count($this->requests[spl_object_id($request)])-1];
+        $entry['endTime'] = microtime(true);
+        $entry['totalTime'] = $entry['endTime'] - $entry['startTime'];
+    }
+}

--- a/src/Collector/HttpClientCollector.php
+++ b/src/Collector/HttpClientCollector.php
@@ -23,7 +23,7 @@ final class HttpClientCollector implements CollectorInterface, IndexCollectorInt
                 'totalTime' => array_sum(
                     array_merge(
                         ...array_map(
-                            fn(array $entry) => array_column($entry, 'totalTime'),
+                            fn (array $entry) => array_column($entry, 'totalTime'),
                             $this->requests
                         )
                     )

--- a/src/Collector/HttpClientInterfaceProxy.php
+++ b/src/Collector/HttpClientInterfaceProxy.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Yii\Debug\Collector;
+
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+final class HttpClientInterfaceProxy implements ClientInterface
+{
+    public function __construct(private ClientInterface $decorated, private HttpClientCollector $collector)
+    {
+    }
+
+    public function sendRequest(RequestInterface $request): ResponseInterface
+    {
+        [$callStack] = debug_backtrace();
+
+        $this->collector->collect($request, $callStack['file'] . ':' . $callStack['line']);
+
+        try {
+            return $this->decorated->sendRequest($request);
+        } finally {
+            $this->collector->collectTotalTime($request);
+        }
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌

Install any psr/http-client compatible library, inject `Psr\Http\Client\ClientInterface`, do something like this:
```php
$request = new \GuzzleHttp\Psr7\Request('GET', 'http://httpbin.org');
$request2 = new \GuzzleHttp\Psr7\Request('GET', 'http://httpbin.org');
$c = $client->sendRequest($request);
$c = $client->sendRequest($request);
$c = $client->sendRequest($request);
$c = $client->sendRequest($request2);
```
And you well see the new sections `http` and `Yiisoft\Yii\Debug\Collector\HttpClientCollector` at `index` and common collected result respectively.