### PR TITLE
Fix #282: Don't dump objects that are absent in the objects cache

### DIFF
--- a/src/Dumper.php
+++ b/src/Dumper.php
@@ -164,6 +164,11 @@ final class Dumper
                     break;
                 }
 
+                if (!array_key_exists($objectDescription, $this->objects)) {
+                    $output = $objectDescription . ' (...)';
+                    break;
+                }
+
                 $properties = $this->getObjectProperties($variable);
                 if (empty($properties)) {
                     if ($inlineObject) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌

#282
