### PR TITLE
Remove `withIgnoredRequests()` and `withIgnoredCommands()` methods from `Debugger`

### DIFF
--- a/src/Debugger.php
+++ b/src/Debugger.php
@@ -39,8 +39,8 @@ final class Debugger
     public function __construct(
         private readonly StorageInterface $storage,
         array $collectors,
-        private array $ignoredRequests = [],
-        private array $ignoredCommands = [],
+        private readonly array $ignoredRequests = [],
+        private readonly array $ignoredCommands = [],
         array $excludedClasses = [],
     ) {
         $preparedCollectors = [];
@@ -153,30 +153,6 @@ final class Debugger
             }
         }
         return false;
-    }
-
-    /**
-     * @param string[] $ignoredRequests Patterns for ignored request URLs.
-     *
-     * @see WildcardPattern
-     */
-    public function withIgnoredRequests(array $ignoredRequests): self
-    {
-        $new = clone $this;
-        $new->ignoredRequests = $ignoredRequests;
-        return $new;
-    }
-
-    /**
-     * @param string[] $ignoredCommands Patterns for ignored commands names.
-     *
-     * @see WildcardPattern
-     */
-    public function withIgnoredCommands(array $ignoredCommands): self
-    {
-        $new = clone $this;
-        $new->ignoredCommands = $ignoredCommands;
-        return $new;
     }
 
     /**

--- a/tests/Unit/DebuggerTest.php
+++ b/tests/Unit/DebuggerTest.php
@@ -37,14 +37,6 @@ final class DebuggerTest extends TestCase
         $debugger->startup(new BeforeRequest(new ServerRequest('GET', '/debug')));
     }
 
-    public function testWithIgnoredRequests(): void
-    {
-        $debugger1 = new Debugger(new MemoryStorage(), []);
-        $debugger2 = $debugger1->withIgnoredRequests(['/test']);
-
-        $this->assertNotSame($debugger1, $debugger2);
-    }
-
     public function testIgnoreByHeader(): void
     {
         $collector = $this->getMockBuilder(CollectorInterface::class)->getMock();
@@ -55,14 +47,6 @@ final class DebuggerTest extends TestCase
         $debugger = new Debugger($storage, [$collector], []);
         $debugger->startup(new BeforeRequest(new ServerRequest('GET', '/test', ['X-Debug-Ignore' => 'true'])));
         $debugger->shutdown();
-    }
-
-    public function testWithIgnoredCommands(): void
-    {
-        $debugger1 = new Debugger(new MemoryStorage(), []);
-        $debugger2 = $debugger1->withIgnoredCommands(['command/test']);
-
-        $this->assertNotSame($debugger1, $debugger2);
     }
 
     public function testIgnoreByEnv(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ✔️
